### PR TITLE
use lambda forms with an explict type annotation

### DIFF
--- a/typed/measures-with-dimensions/chemistry/compound-struct.rkt
+++ b/typed/measures-with-dimensions/chemistry/compound-struct.rkt
@@ -18,7 +18,8 @@ require racket/match
   #:property prop:custom-write
   (lambda ([comp : Compound] [out : Output-Port] [mode : (Un 0 1 #t #f)])
     (match mode
-      [_ #:when (andmap zero? (map cdr (compound-alist comp)))
+      [_ #:when (andmap zero? (map (inst cdr (Un Element Compound) Natural)
+                                   (compound-alist comp)))
          (write-string "#<compound:>" out) (void)]
       [(or 0 #f) (display-compound comp out)]
       [(or 1 #t) (write-string "#<componud:" out)


### PR DESCRIPTION
1. After the [pull request ](https://github.com/racket/typed-racket/pull/804/) is released, a struct's struct property values will be type-checked.  

The current property value of prop:custom-write for `struct compound` is potentially problematic. At line 21, we have to provide more type information to the argument function of `map` to make the typechecker happy. 

2. Though `(Un 0 1 #t #f)` is acceptable, the type of `mode` is actually `Boolean`. Also, I refactored the control flow a little bit. 